### PR TITLE
Content overflows, no scrollbar on smaller display

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,10 @@
   src: local('Roboto Condensed Regular'), local('RobotoCondensed-Regular'), url(assets/RobotoCondensed.woff) format('woff');
 }
 
+html {
+  overflow-y:scroll;
+}
+
 body {
   background: linear-gradient(180deg, #11575c 0%,#3b8766 100%) no-repeat #3b8766;
   margin: 0px auto;


### PR DESCRIPTION
Adding overflow-y:scroll attribute to html styling per https://gist.github.com/maicki/7622137
